### PR TITLE
Fixed old Online-Sandbox URL

### DIFF
--- a/tests/sdk/RequestPaymentTest.php
+++ b/tests/sdk/RequestPaymentTest.php
@@ -118,7 +118,7 @@ class RequestPaymentTest extends PHPUnit_Framework_TestCase {
     $xmlResponse = '<?xml version="1.0" encoding="UTF-8"?>
                     <response>
                       <transaction-id>7690927</transaction-id>
-                      <payment-slip-link>https://api-online-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf</payment-slip-link>
+                      <payment-slip-link>https://api-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf</payment-slip-link>
                       <expiration-notice>Der Zahlschein ist 14 Tage gültig.</expiration-notice>
                       <infotext-1><![CDATA[Hallo <b>Welt</b>! <a href="http://www.barzahlen.de">Bar zahlen</a> Infütöxt Äinß]]></infotext-1>
                       <infotext-2><![CDATA[Hallo <i>Welt</i>! <a href="http://www.barzahlen.de?a=b&c=d">Bar zahlen</a> Infütöxt 2% & so weiter]]></infotext-2>
@@ -130,7 +130,7 @@ class RequestPaymentTest extends PHPUnit_Framework_TestCase {
     $payment->parseXml($xmlResponse, PAYMENTKEY);
 
     $this->assertEquals('7690927', $payment->getTransactionId());
-    $this->assertEquals('https://api-online-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf', $payment->getPaymentSlipLink());
+    $this->assertEquals('https://api-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf', $payment->getPaymentSlipLink());
     $this->assertEquals('Der Zahlschein ist 14 Tage gültig.', $payment->getExpirationNotice());
     $this->assertEquals('Hallo <b>Welt</b>! <a href="http://www.barzahlen.de">Bar zahlen</a> Infütöxt Äinß', $payment->getInfoText1());
     $this->assertEquals('Hallo <i>Welt</i>! <a href="http://www.barzahlen.de?a=b&c=d">Bar zahlen</a> Infütöxt 2% & so weiter', $payment->getInfoText2());
@@ -181,7 +181,7 @@ class RequestPaymentTest extends PHPUnit_Framework_TestCase {
     $xmlResponse = '<?xml version="1.0" encoding="UTF-8"?>
                     <response>
                       <transaction-id>7690927</transaction-id>
-                      <payment-slip-link>https://api-online-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf</payment-slip-link>
+                      <payment-slip-link>https://api-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf</payment-slip-link>
                       <expiration-notice>Der Zahlschein ist 14 Tage gültig.</expiration-notice>
                       <result>0</result>
                       <hash>5a175d4002e91f4b16758ff4b8b41ff973ad355e48e73d386195cb8605600d18e443819c4e7044ebb5853a45ff9ffe75b6868e33cc98459494b656301991c18e</hash>
@@ -203,7 +203,7 @@ class RequestPaymentTest extends PHPUnit_Framework_TestCase {
     $xmlResponse = '<?xml version="1.0" encoding="UTF-8"?>
                     <response>
                       <transaction-id>7690927</transaction-id>
-                      <payment-slip-link>https://api-online-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf</payment-slip-link>
+                      <payment-slip-link>https://api-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf</payment-slip-link>
                       <expiration-notice>Der Zahlschein ist 14 Tage gültig.</expiration-notice>
                       <infotext-1><![CDATA[Hallo <b>Welt</b>! <a href="http://www.barzahlen.de">Bar zahlen</a> Infütöxt Äinß]]></infotext-1>
                       <infotext-2><![CDATA[Hallo <i>Welt</i>! <a href="http://www.barzahlen.de?a=b&c=d">Bar zahlen</a> Infütöxt 2% & so weiter]]></infotext-2>
@@ -227,7 +227,7 @@ class RequestPaymentTest extends PHPUnit_Framework_TestCase {
     $xmlResponse = '<?xml version="1.0" encoding="UTF-8"?>
                     <response>
                       <transaction-id>7690927</some-id>
-                      <payment-slip-link>https://api-online-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf</payment-slip-link>
+                      <payment-slip-link>https://api-sandbox.barzahlen.de:904/download/2001048300000/b3fc66ebb5f60ddfaa20307c73e0db3b73c0d812c1dc7e64984c5e2d4b64799a/Zahlschein_Barzahlen.pdf</payment-slip-link>
                       <expiration-notice>Der Zahlschein ist 14 Tage gültig.</expiration-notice>
                       <infotext-1><![CDATA[Hallo <b>Welt</b>! <a href="http://www.barzahlen.de">Bar zahlen</a> Infütöxt Äinß]]></infotext-1>
                       <infotext-2><![CDATA[Hallo <i>Welt</i>! <a href="http://www.barzahlen.de?a=b&c=d">Bar zahlen</a> Infütöxt 2% & so weiter]]></infotext-2>


### PR DESCRIPTION
The RequestPaymentTest.php still contained the old API-Online-Sandbox URLs and are now fixed for the the URL Schema
