### PR TITLE
Update api url from barzahlen.de to viafintech.com

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "license": "MIT",
     "type": "library",
     "keywords": ["payment", "Barzahlen", "viafintech"],
-    "homepage": "https://www.barzahlen.de",
+    "homepage": "https://www.viafintech.com",
     "support": {
-        "email": "support@barzahlen.de",
-        "issues": "https://github.com/Barzahlen/Barzahlen-PHP/issues"
+        "email": "support@viafintech.com",
+        "issues": "https://github.com/viafintech/Barzahlen-PHP/issues"
     },
     "authors": [
         {

--- a/readme.md
+++ b/readme.md
@@ -5,13 +5,13 @@
 [![License](https://poser.pugx.org/barzahlen/barzahlen-php/license)](https://packagist.org/packages/barzahlen/barzahlen-php)
 
 ## Copyright
-(c) 2016-2020, viafintech GmbH  
-https://www.barzahlen.de
+(c) 2016-2021, viafintech GmbH  
+https://www.viafintech.com
 
 ## Preparation
 
 ### API Credentials
-The API credentials, which are necessary to use the Barzahlen API, can be received at [Barzahlen Control Center](https://controlcenter.barzahlen.de). After a successful registration a division ID is assigned to you as well as a payment key.
+The API credentials, which are necessary to use the Barzahlen API, can be received at [Barzahlen Control Center](https://controlcenter.viacash.com). After a successful registration a division ID is assigned to you as well as a payment key.
 
 ### Installation
 The Barzahlen PHP SDK can be installed using Composer.
@@ -121,7 +121,7 @@ $request->setTransaction('-14.95', 'EUR');
 ```
 
 #### More parameters
-You may set more parameters according to the [Barzahlen API v2 Documentation](https://docs.barzahlen.de/api/v2/).
+You may set more parameters according to the [Barzahlen API v2 Documentation](https://docs.viafintech.com/api/v2/).
 
 ```php
 $request->setReferenceKey('REFKEY123');
@@ -263,7 +263,7 @@ Representation of current slip status. (Content depends on sent parameters.)
 ```
 
 ### UpdateRequest
-To change slip parameters afterwards initiate a new UpdateRequest using the slip id. Use setters, an array or a json string to set your new or updated parameter(s). Only pending slips can be updated. For more information please read the [Barzahlen API v2 Documentation](https://docs.barzahlen.de/api/v2/).
+To change slip parameters afterwards initiate a new UpdateRequest using the slip id. Use setters, an array or a json string to set your new or updated parameter(s). Only pending slips can be updated. For more information please read the [Barzahlen API v2 Documentation](https://docs.viafintech.com/api/v2/).
 
 ```php
 use Barzahlen\Request\UpdateRequest;
@@ -338,4 +338,4 @@ if ($webhook->verify($header, $body)) {
 ## Support
 The Barzahlen Team will happily assist you with any problems or questions.
 
-Send us an email to support@barzahlen.de or use the contact form at https://integration.barzahlen.de/en/support.
+Send us an email to support@viafintech.com or use the contact form at https://integration.barzahlen.de/en/support.

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,9 +7,9 @@ use Barzahlen\Exception as Exception;
 
 class Client
 {
-    const API_URL = 'https://api.barzahlen.de:443/v2';
+    const API_URL = 'https://api.viafintech.com:443/v2';
 
-    const API_SANDBOX_URL = 'https://api-sandbox.barzahlen.de:443/v2';
+    const API_SANDBOX_URL = 'https://api-sandbox.viafintech.com:443/v2';
 
     /**
      * @var string
@@ -80,14 +80,14 @@ class Client
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
-        
+
         if($bHeader) {
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($curl, CURLOPT_HEADER, 1);
         }
 
         $response = curl_exec($curl);
-        
+
         if($bRaw) {
             return $response;
         }

--- a/tests/AutocorrectTest.php
+++ b/tests/AutocorrectTest.php
@@ -41,11 +41,11 @@ class AutocorrectTest extends \PHPUnit\Framework\TestCase
     public function testCorrectHookUrl() {
 
         //check against correct value
-        $sUrl = "https://api.barzahlen.de";
+        $sUrl = "https://api.viafintech.com";
         $this->assertEquals($sUrl, $this->_oObject->correctHookUrl($sUrl));
 
         //check against incorrect value, which should have been corrected
-        $sUrlWrong = "http://api.barzahlen.de"; //missing https
+        $sUrlWrong = "http://api.viafintech.com"; //missing https
         $this->assertEquals($sUrl, $this->_oObject->correctHookUrl($sUrlWrong));
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -43,7 +43,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $request->setTransaction('24.95', 'EUR');
 
         $header = $this->client->buildHeader($request);
-        $this->assertEquals('Host: api.barzahlen.de', $header[0]);
+        $this->assertEquals('Host: api.viafintech.com', $header[0]);
         $this->assertContains('Date: ', $header[1]);
         $this->assertEquals('User-Agent: '.$this->userAgent, $header[2]);
         $this->assertRegExp('/^Authorization: BZ1-HMAC-SHA256 DivisionId=12345, Signature=[a-f0-9]{64}$/', $header[3]);
@@ -56,7 +56,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $client = new Client(DIVISIONID, PAYMENTKEY, true);
 
         $header = $client->buildHeader($request);
-        $this->assertEquals('Host: api-sandbox.barzahlen.de', $header[0]);
+        $this->assertEquals('Host: api-sandbox.viafintech.com', $header[0]);
         $this->assertContains('Date: ', $header[1]);
         $this->assertEquals('User-Agent: '.$this->userAgent, $header[2]);
         $this->assertRegExp('/^Authorization: BZ1-HMAC-SHA256 DivisionId=12345, Signature=[a-f0-9]{64}$/', $header[3]);


### PR DESCRIPTION
In the context of the rebranding we are also updating the domain
for our API.
This change reflects this in the library so that in the future
requests will be made against this API instead