### PR TITLE
Deprecated Warning in PHP 8.1

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -24,7 +24,7 @@ class Middleware
             $query,
             $date,
             $idempotency,
-            hash('sha256', ($body == null) ? "" : $body)
+            hash('sha256', $body ?? "")
         );
         $signatureString = implode("\n", $signatureData);
 

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -24,7 +24,7 @@ class Middleware
             $query,
             $date,
             $idempotency,
-            hash('sha256', $body)
+            hash('sha256', ($body == null) ? "" : $body)
         );
         $signatureString = implode("\n", $signatureData);
 


### PR DESCRIPTION
hash(): Passing null to parameter #2 ($data) of type string is deprecated in barzahlen/barzahlen-php/src/Middleware.php on line 27